### PR TITLE
COW file fails to truncate/unlink

### DIFF
--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -761,8 +761,19 @@ error:
 int cow_truncate_to_index(struct cow_manager *cm)
 {
         // truncate the cow file to just the index
+
+        file_unlock(cm->filp);
+
         cm->flags |= (1 << COW_INDEX_ONLY);
-        return file_truncate(cm->filp, cm->data_offset);
+        int ret = file_truncate(cm->filp, cm->data_offset);
+        
+        if(!ret){
+                cm->file_max = cm->data_offset;
+        }
+
+        file_lock(cm->filp);
+
+        return ret;
 }
 
 /**

--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -761,16 +761,8 @@ error:
 int cow_truncate_to_index(struct cow_manager *cm)
 {
         // truncate the cow file to just the index
-
-        file_unlock(cm->filp);
-
         cm->flags |= (1 << COW_INDEX_ONLY);
-        int ret = file_truncate(cm->filp, cm->data_offset);
-        
-
-        file_lock(cm->filp);
-
-        return ret;
+        return file_truncate(cm->filp, cm->data_offset);
 }
 
 /**

--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -767,9 +767,6 @@ int cow_truncate_to_index(struct cow_manager *cm)
         cm->flags |= (1 << COW_INDEX_ONLY);
         int ret = file_truncate(cm->filp, cm->data_offset);
         
-        if(!ret){
-                cm->file_max = cm->data_offset;
-        }
 
         file_lock(cm->filp);
 

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -656,6 +656,7 @@ static int dattobd_do_truncate(struct dentry *dentry, loff_t length,
                 newattrs.ia_valid |= ret | ATTR_FORCE;
 
         dattobd_inode_lock(dentry->d_inode);
+        inode_attr_unlock(dentry->d_inode);
 #ifdef HAVE_NOTIFY_CHANGE_2
         //#if LINUX_VERSION_CODE < KERNEL_VERSION(3,13,0)
         ret = notify_change(dentry, &newattrs);
@@ -667,6 +668,7 @@ static int dattobd_do_truncate(struct dentry *dentry, loff_t length,
 #else
         ret = notify_change(dentry, &newattrs, NULL);
 #endif
+        inode_attr_lock(dentry->d_inode);
         dattobd_inode_unlock(dentry->d_inode);
 
         return ret;
@@ -885,8 +887,8 @@ int __file_unlink(struct file *filp, int close, int force)
         struct dentry *file_dentry = dattobd_get_dentry(filp);
         struct vfsmount *mnt = dattobd_get_mnt(filp);
 
-        if(file_dentry->d_inode && inode_is_locked(file_dentry->d_inode)){
-                file_unlock(filp);
+        if(file_dentry->d_inode && inode_attr_is_locked(file_dentry->d_inode)){
+                inode_attr_unlock(file_dentry->d_inode);
         }
 
         if (d_unlinked(file_dentry)) {
@@ -1067,9 +1069,9 @@ void file_switch_lock(struct file* filp, bool lock, bool mark_dirty)
         igrab(inode);
 
         if(lock){
-                inode->i_flags |= S_IMMUTABLE;
+                inode_attr_lock(inode);
         }else{
-                inode->i_flags &= ~S_IMMUTABLE;
+                inode_attr_unlock(inode);
         }
 
         if(mark_dirty){

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -885,6 +885,10 @@ int __file_unlink(struct file *filp, int close, int force)
         struct dentry *file_dentry = dattobd_get_dentry(filp);
         struct vfsmount *mnt = dattobd_get_mnt(filp);
 
+        if(file_dentry->d_inode && inode_is_locked(file_dentry->d_inode)){
+                file_unlock(filp);
+        }
+
         if (d_unlinked(file_dentry)) {
                 if (close)
                         file_close(filp);

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -21,7 +21,11 @@
 #define file_lock(filp) file_switch_lock(filp, true, false)
 #define file_unlock(filp) file_switch_lock(filp, false, false)
 #define file_unlock_mark_dirty(filp) file_switch_lock(filp, false, true)
-#define inode_is_locked(inode) ( (inode->i_flags) & S_IMMUTABLE)
+
+// INODE Attribute Locking is based on the S_IMMUTABLE flag
+#define inode_attr_is_locked(inode) ( (inode->i_flags) & S_IMMUTABLE )
+#define inode_attr_lock(inode) do{ inode->i_flags |= S_IMMUTABLE; } while(0)
+#define inode_attr_unlock(inode) do{ inode->i_flags &= ~S_IMMUTABLE; } while(0)
 
 #ifndef HAVE_STRUCT_PATH
 //#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,20)

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -21,6 +21,7 @@
 #define file_lock(filp) file_switch_lock(filp, true, false)
 #define file_unlock(filp) file_switch_lock(filp, false, false)
 #define file_unlock_mark_dirty(filp) file_switch_lock(filp, false, true)
+#define inode_is_locked(inode) ( (inode->i_flags) & S_IMMUTABLE)
 
 #ifndef HAVE_STRUCT_PATH
 //#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,20)


### PR DESCRIPTION
DattoBD failed to truncate file after transition from snapshot to incremental and failed to unlink file on reboot on Debian-based systems.

Fixed that implementing `file_lock/file_unlock` mechanism also to `file_truncate` and `__file_unlink` procedures.