### PR TITLE
[FEATURE] COW-file Manual Expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The current status of the dattobd driver can be read from the file `/proc/datto-
 * `block_device`: The block device being tracked by this device.
 * `max_cache`: The maximum amount of memory that may be used to cache metadata for this device (in bytes).
 * `fallocate`: The preallocated size of the cow file (in bytes). This will not be printed if the device is in the unverified state.
+* `cow_size_current`: The current size of the cow file (in bytes). This will not be printed if the device is in the unverified state.
 * `seq_id`: The sequence id of the snapshot. This number starts at 1 for new snapshots and is incremented on each transition to snapshot.
 * `uuid`: Uniquely identifies a series of snapshots. It is not changed on state transition.
 * `error`: This field will only be present if the device has failed. It shows the linux standard error code indicating what went wrong. More specific info is printed to dmesg.

--- a/app/bash_completion.d/dbdctl
+++ b/app/bash_completion.d/dbdctl
@@ -4,7 +4,7 @@ _dbdctl()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="setup-snapshot reload-snapshot reload-incremental destroy transition-to-incremental transition-to-snapshot reconfigure help"
+    opts="setup-snapshot reload-snapshot reload-incremental destroy transition-to-incremental transition-to-snapshot reconfigure expand-cow-file help"
 
     if [[ ${cur} == * ]] ; then
         COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )

--- a/app/dbdctl.c
+++ b/app/dbdctl.c
@@ -23,6 +23,7 @@ static void print_help(int status){
 	printf("\tdbdctl transition-to-incremental <minor>\n");
 	printf("\tdbdctl transition-to-snapshot [-f fallocate] <cow file> <minor>\n");
 	printf("\tdbdctl reconfigure [-c <cache size>] <minor>\n");
+	printf("\tdbdctl extend-cow <minor> <size>\n");
 	printf("\tdbdctl help\n\n");
 	printf("<cow file> should be specified as an absolute path.\n");
 	printf("cache size should be provided in bytes, and fallocate should be provided in megabytes.\n");
@@ -315,6 +316,30 @@ error:
 	return 0;
 }
 
+static int handle_cow_extend(int argc, char **argv){
+	int ret;
+	unsigned int minor;
+	unsigned long size;
+
+	if(argc != 3){
+		errno = EINVAL;
+		goto error;
+	}
+
+	ret = parse_ui(argv[1], &minor);
+	if(ret) goto error;
+
+	ret = parse_ul(argv[2], &size);
+	if(ret) goto error;
+
+	return dattobd_extend_cow(minor, size);
+
+error:
+	perror("error interpreting destroy parameters");
+	print_help(-1);
+	return 0;
+}
+
 int main(int argc, char **argv){
 	int ret = 0;
 
@@ -335,6 +360,7 @@ int main(int argc, char **argv){
 	else if(!strcmp(argv[1], "transition-to-incremental")) ret = handle_transition_inc(argc - 1, argv + 1);
 	else if(!strcmp(argv[1], "transition-to-snapshot")) ret = handle_transition_snap(argc - 1, argv + 1);
 	else if(!strcmp(argv[1], "reconfigure")) ret = handle_reconfigure(argc - 1, argv + 1);
+	else if(!strcmp(argv[1], "extend-cow")) ret = handle_cow_extend(argc - 1, argv + 1);
 	else if(!strcmp(argv[1], "help")) print_help(0);
 	else print_help(-1);
 

--- a/app/dbdctl.c
+++ b/app/dbdctl.c
@@ -23,7 +23,7 @@ static void print_help(int status){
 	printf("\tdbdctl transition-to-incremental <minor>\n");
 	printf("\tdbdctl transition-to-snapshot [-f fallocate] <cow file> <minor>\n");
 	printf("\tdbdctl reconfigure [-c <cache size>] <minor>\n");
-	printf("\tdbdctl extend-cow <minor> <size>\n");
+	printf("\tdbdctl expand-cow-file <minor> <size>\n");
 	printf("\tdbdctl help\n\n");
 	printf("<cow file> should be specified as an absolute path.\n");
 	printf("cache size should be provided in bytes, and fallocate should be provided in megabytes.\n");
@@ -316,7 +316,7 @@ error:
 	return 0;
 }
 
-static int handle_cow_extend(int argc, char **argv){
+static int handle_expand_cow_file(int argc, char **argv){
 	int ret;
 	unsigned int minor;
 	unsigned long size;
@@ -332,10 +332,10 @@ static int handle_cow_extend(int argc, char **argv){
 	ret = parse_ul(argv[2], &size);
 	if(ret) goto error;
 
-	return dattobd_extend_cow(minor, size);
+	return dattobd_expand_cow_file(minor, size);
 
 error:
-	perror("error interpreting destroy parameters");
+	perror("error interpreting expand parameters");
 	print_help(-1);
 	return 0;
 }
@@ -360,7 +360,7 @@ int main(int argc, char **argv){
 	else if(!strcmp(argv[1], "transition-to-incremental")) ret = handle_transition_inc(argc - 1, argv + 1);
 	else if(!strcmp(argv[1], "transition-to-snapshot")) ret = handle_transition_snap(argc - 1, argv + 1);
 	else if(!strcmp(argv[1], "reconfigure")) ret = handle_reconfigure(argc - 1, argv + 1);
-	else if(!strcmp(argv[1], "extend-cow")) ret = handle_cow_extend(argc - 1, argv + 1);
+	else if(!strcmp(argv[1], "expand-cow-file")) ret = handle_expand_cow_file(argc - 1, argv + 1);
 	else if(!strcmp(argv[1], "help")) print_help(0);
 	else print_help(-1);
 

--- a/doc/dbdctl.8
+++ b/doc/dbdctl.8
@@ -74,6 +74,12 @@ Cleanly and completely removes the snapshot or incremental, unlinking the associ
 .P
 Allows you to reconfigure various parameters of a snapshot while it is online\. Currently only the index cache size (given in MB) can be changed dynamically\.
 .
+.SS "expand-cow-file"
+\fBdbdctl expand-cow-file <minor> <size>\fR
+.
+.P
+Expands cow file in snapshot mode by size (given in bytes)\.
+.
 .SS "EXAMPLES"
 \fB# dbdctl setup\-snapshot /dev/sda1 /var/backup/datto 4\fR
 .

--- a/doc/dbdctl.8.html
+++ b/doc/dbdctl.8.html
@@ -140,6 +140,12 @@
 
 <p>Allows you to reconfigure various parameters of a snapshot while it is online. Currently only the index cache size (given in MB) can be changed dynamically.</p>
 
+<h3 id="expand-cow-file">expand-cow-file</h3>
+
+<p><code>dbdctl expand-cow-file &lt;minor&gt; &lt;size&gt;</code></p>
+
+<p>Expands cow file in snapshot mode by size (given in bytes).</p>
+
 <h3 id="EXAMPLES">EXAMPLES</h3>
 
 <p><code># dbdctl setup-snapshot /dev/sda1 /var/backup/datto 4</code></p>

--- a/doc/dbdctl.8.md
+++ b/doc/dbdctl.8.md
@@ -63,6 +63,12 @@ Cleanly and completely removes the snapshot or incremental, unlinking the associ
 
 Allows you to reconfigure various parameters of a snapshot while it is online. Currently only the index cache size (given in MB) can be changed dynamically.
 
+### expand-cow-file
+
+`dbdctl expand-cow-file <minor> <size>`
+
+Expands cow file in snapshot mode by size (given in bytes).
+
 ### EXAMPLES
 
 `# dbdctl setup-snapshot /dev/sda1 /var/backup/datto 4`

--- a/lib/libdattobd.c
+++ b/lib/libdattobd.c
@@ -154,3 +154,18 @@ int dattobd_get_free_minor(void){
 	if(!ret) return minor;
 	return ret;
 }
+
+int dattobd_extend_cow(unsigned int minor, unsigned long size){
+	int fd, ret;
+	struct extend_cow_params params;
+	params.minor=minor;
+	params.size=size;
+
+	fd = open("/dev/datto-ctl", O_RDONLY);
+	if(fd < 0) return -1;
+
+	ret = ioctl(fd, IOCTL_EXTEND_COW, &params);
+
+	close(fd);
+	return ret;
+}

--- a/lib/libdattobd.c
+++ b/lib/libdattobd.c
@@ -155,16 +155,16 @@ int dattobd_get_free_minor(void){
 	return ret;
 }
 
-int dattobd_extend_cow(unsigned int minor, unsigned long size){
+int dattobd_expand_cow_file(unsigned int minor, unsigned long size){
 	int fd, ret;
-	struct extend_cow_params params;
+	struct expand_cow_file_params params;
 	params.minor=minor;
 	params.size=size;
 
 	fd = open("/dev/datto-ctl", O_RDONLY);
 	if(fd < 0) return -1;
 
-	ret = ioctl(fd, IOCTL_EXTEND_COW, &params);
+	ret = ioctl(fd, IOCTL_EXPAND_COW_FILE, &params);
 
 	close(fd);
 	return ret;

--- a/lib/libdattobd.h
+++ b/lib/libdattobd.h
@@ -29,7 +29,7 @@ int dattobd_reconfigure(unsigned int minor, unsigned long cache_size);
 
 int dattobd_info(unsigned int minor, struct dattobd_info *info);
 
-int dattobd_extend_cow(unsigned int minor, unsigned long size);
+int dattobd_expand_cow_file(unsigned int minor, unsigned long size);
 
 /**
  * Get the first available minor.

--- a/lib/libdattobd.h
+++ b/lib/libdattobd.h
@@ -29,6 +29,8 @@ int dattobd_reconfigure(unsigned int minor, unsigned long cache_size);
 
 int dattobd_info(unsigned int minor, struct dattobd_info *info);
 
+int dattobd_extend_cow(unsigned int minor, unsigned long size);
+
 /**
  * Get the first available minor.
  *

--- a/src/bdev_state_handler.c
+++ b/src/bdev_state_handler.c
@@ -68,7 +68,7 @@ int __handle_bdev_mount_nowrite(const struct vfsmount *mnt,
                     dev->sd_base_dev != mnt->mnt_sb->s_bdev)
                         continue;
 
-                if (mnt == dattobd_get_mnt(dev->sd_cow->filp)) {
+                if (mnt == dattobd_get_mnt(dev->sd_cow->dfilp->filp)) {
                         LOG_DEBUG("block device umount detected for device %d",
                                   i);
                         auto_transition_dormant(i);

--- a/src/bdev_state_handler.c
+++ b/src/bdev_state_handler.c
@@ -68,7 +68,7 @@ int __handle_bdev_mount_nowrite(const struct vfsmount *mnt,
                     dev->sd_base_dev != mnt->mnt_sb->s_bdev)
                         continue;
 
-                if (mnt == dattobd_get_mnt(dev->sd_cow->dfilp->filp)) {
+                if (mnt == dev->sd_cow->dfilp->mnt) {
                         LOG_DEBUG("block device umount detected for device %d",
                                   i);
                         auto_transition_dormant(i);

--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -1144,15 +1144,14 @@ out:
 int cow_extend_datastore(struct snap_device* dev, uint64_t append_size){
         int ret;
         struct cow_manager *cm = dev->sd_cow;
-        uint64_t new_file_max = cm->file_max + append_size;
         uint64_t curr_max = cm->file_max;
 
-        ret = file_allocate(cm->filp, cm->dev, cm->file_max, new_file_max);
+        ret = file_allocate(cm->filp, cm->dev, cm->file_max, append_size);
         if (ret){
                 LOG_ERROR(ret, "unable to increase cow file size");
                 return ret;
         }
 
-        cm->file_max = new_file_max;
+        cm->file_max = cm->file_max + append_size;
         return 0;
 }

--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -1141,7 +1141,7 @@ out:
 }
 
 
-int cow_extend_datastore(struct snap_device* dev, uint64_t append_size){
+int cow_expand_datastore(struct snap_device* dev, uint64_t append_size){
         int ret;
         struct cow_manager *cm = dev->sd_cow;
         uint64_t curr_max = cm->file_max;
@@ -1150,11 +1150,11 @@ int cow_extend_datastore(struct snap_device* dev, uint64_t append_size){
         ret = file_allocate(cm->filp, cm->dev, cm->file_max, append_size, &actual);
 
         if(actual != append_size){
-                LOG_WARN("cow file size not extended to requested size (req: %llu, act: %llu)", append_size, actual);
+                LOG_WARN("cow file was not expanded to requested size (req: %llu, act: %llu)", append_size, actual);
         }
 
         if (ret && !actual){
-                LOG_ERROR(ret, "unable to increase cow file size");
+                LOG_ERROR(ret, "unable to expand cow file");
                 return ret;
         }
 

--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -1185,9 +1185,8 @@ out:
 }
 
 
-int cow_expand_datastore(struct cow_manager* cm, uint64_t append_size){
+int __cow_expand_datastore(struct cow_manager* cm, uint64_t append_size){
         int ret;
-        uint64_t curr_max = cm->file_size;
         uint64_t actual = 0;
 
         ret = file_allocate(cm->dfilp, cm->dev, cm->file_size, append_size, &actual);
@@ -1196,11 +1195,12 @@ int cow_expand_datastore(struct cow_manager* cm, uint64_t append_size){
                 LOG_WARN("cow file was not expanded to requested size (req: %llu, act: %llu)", append_size, actual);
         }
 
-        if (ret && !actual){
+        cm->file_size = cm->file_size + actual;
+
+        if (ret){
                 LOG_ERROR(ret, "unable to expand cow file");
                 return ret;
         }
 
-        cm->file_size = cm->file_size + actual;
         return 0;
 }

--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -1185,9 +1185,8 @@ out:
 }
 
 
-int cow_expand_datastore(struct snap_device* dev, uint64_t append_size){
+int cow_expand_datastore(struct cow_manager* cm, uint64_t append_size){
         int ret;
-        struct cow_manager *cm = dev->sd_cow;
         uint64_t curr_max = cm->file_size;
         uint64_t actual = 0;
 

--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -1139,3 +1139,20 @@ out:
 	__free_pages(pg, get_order(cow_ext_buf_size));
 	return ret;
 }
+
+
+int cow_extend_datastore(struct snap_device* dev, uint64_t append_size){
+        int ret;
+        struct cow_manager *cm = dev->sd_cow;
+        uint64_t new_file_max = cm->file_max + append_size;
+        uint64_t curr_max = cm->file_max;
+
+        ret = file_allocate(cm->filp, cm->dev, cm->file_max, new_file_max);
+        if (ret){
+                LOG_ERROR(ret, "unable to increase cow file size");
+                return ret;
+        }
+
+        cm->file_max = new_file_max;
+        return 0;
+}

--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -99,11 +99,11 @@ int __cow_load_section(struct cow_manager *cm, unsigned long sect_idx)
 		int mapping_offset = (COW_BLOCK_SIZE / sizeof(cm->sects[sect_idx].mappings[0])) * i;
 		int cow_file_offset = COW_BLOCK_SIZE * i;
 
-        ret = file_read(cm->filp, cm->dev, cm->sects[sect_idx].mappings,
-                        cm->sect_size * sect_idx * 8 + COW_HEADER_SIZE,
-                        cm->sect_size * 8);
-        if (ret)
-                goto error;
+                ret = file_read(cm->filp, cm->dev, cm->sects[sect_idx].mappings,
+                                cm->sect_size * sect_idx * 8 + COW_HEADER_SIZE,
+                                cm->sect_size * 8);
+                if (ret)
+                        goto error;
         }
 
         return 0;

--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -947,7 +947,7 @@ static int __cow_write_data(struct cow_manager *cm, void *buf)
         if (curr_size >= cm->file_max) {
                 ret = -EFBIG;
 
-                file_get_absolute_pathname(cm->dfilp->filp, &abs_path, &abs_path_len);
+                file_get_absolute_pathname(cm->dfilp, &abs_path, &abs_path_len);
                 if (!abs_path) {
                         LOG_ERROR(ret, "cow file max size exceeded (%llu/%llu)",
                                   curr_size, cm->file_max);

--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -765,7 +765,12 @@ int cow_truncate_to_index(struct cow_manager *cm)
 {
         // truncate the cow file to just the index
         cm->flags |= (1 << COW_INDEX_ONLY);
-        return file_truncate(cm->filp, cm->data_offset);
+        int ret = file_truncate(cm->filp, cm->data_offset);
+
+        if(!ret)
+                cm->file_max = cm->data_offset;
+        
+        return ret;
 }
 
 /**

--- a/src/cow_manager.h
+++ b/src/cow_manager.h
@@ -100,6 +100,6 @@ int __cow_write_mapping(struct cow_manager *cm, uint64_t pos, uint64_t val);
 
 int cow_get_file_extents(struct snap_device* dev, struct file* filp);
 
-int cow_expand_datastore(struct cow_manager *cm, uint64_t append_size);
+int __cow_expand_datastore(struct cow_manager *cm, uint64_t append_size);
 
 #endif /* COW_MANAGER_H_ */

--- a/src/cow_manager.h
+++ b/src/cow_manager.h
@@ -45,7 +45,7 @@ struct cow_manager {
         uint32_t flags; // flags representing current state of cow manager
         uint64_t curr_pos; // current write head position
         uint64_t data_offset; // starting offset of data
-        uint64_t file_max; // max size of the file before an error is thrown
+        uint64_t file_size; // current size of the file, max size before an error is thrown
         uint64_t seqid; // sequence id, increments on each transition to
                         // snapshot mode
         uint64_t version; // version of cow file format

--- a/src/cow_manager.h
+++ b/src/cow_manager.h
@@ -100,4 +100,6 @@ int __cow_write_mapping(struct cow_manager *cm, uint64_t pos, uint64_t val);
 
 int cow_get_file_extents(struct snap_device* dev, struct file* filp);
 
+int cow_extend_datastore(struct snap_device *dev, uint64_t append_size);
+
 #endif /* COW_MANAGER_H_ */

--- a/src/cow_manager.h
+++ b/src/cow_manager.h
@@ -41,7 +41,7 @@ struct cow_section {
 };
 
 struct cow_manager {
-        struct file *filp; // the file the cow manager is writing to
+        struct dattobd_mutable_file *dfilp; // the file the cow manager is writing to
         uint32_t flags; // flags representing current state of cow manager
         uint64_t curr_pos; // current write head position
         uint64_t data_offset; // starting offset of data

--- a/src/cow_manager.h
+++ b/src/cow_manager.h
@@ -100,6 +100,6 @@ int __cow_write_mapping(struct cow_manager *cm, uint64_t pos, uint64_t val);
 
 int cow_get_file_extents(struct snap_device* dev, struct file* filp);
 
-int cow_expand_datastore(struct snap_device *dev, uint64_t append_size);
+int cow_expand_datastore(struct cow_manager *cm, uint64_t append_size);
 
 #endif /* COW_MANAGER_H_ */

--- a/src/cow_manager.h
+++ b/src/cow_manager.h
@@ -100,6 +100,6 @@ int __cow_write_mapping(struct cow_manager *cm, uint64_t pos, uint64_t val);
 
 int cow_get_file_extents(struct snap_device* dev, struct file* filp);
 
-int cow_extend_datastore(struct snap_device *dev, uint64_t append_size);
+int cow_expand_datastore(struct snap_device *dev, uint64_t append_size);
 
 #endif /* COW_MANAGER_H_ */

--- a/src/dattobd.h
+++ b/src/dattobd.h
@@ -46,7 +46,7 @@ struct reconfigure_params {
         unsigned int minor; // requested minor number of the device
 };
 
-struct extend_cow_params {
+struct expand_cow_file_params {
         unsigned int minor; // minor to extend
         unsigned long size; // size in bytes
 };
@@ -110,7 +110,7 @@ struct dattobd_info {
 #define IOCTL_DATTOBD_INFO                                                     \
         _IOR(DATTO_IOCTL_MAGIC, 8, struct dattobd_info) // in: see above
 #define IOCTL_GET_FREE _IOR(DATTO_IOCTL_MAGIC, 9, int)
-#define IOCTL_EXTEND_COW                                                       \
-        _IOW(DATTO_IOCTL_MAGIC, 10, struct extend_cow_params) // in: see above
+#define IOCTL_EXPAND_COW_FILE                                                  \
+        _IOW(DATTO_IOCTL_MAGIC, 10, struct expand_cow_file_params) // in: see above
 
 #endif /* DATTOBD_H_ */

--- a/src/dattobd.h
+++ b/src/dattobd.h
@@ -46,6 +46,11 @@ struct reconfigure_params {
         unsigned int minor; // requested minor number of the device
 };
 
+struct extend_cow_params {
+        unsigned int minor; // minor to extend
+        unsigned long size; // size in bytes
+};
+
 #define COW_UUID_SIZE 16
 #define COW_BLOCK_LOG_SIZE 12
 #define COW_BLOCK_SIZE (1 << COW_BLOCK_LOG_SIZE)
@@ -105,5 +110,7 @@ struct dattobd_info {
 #define IOCTL_DATTOBD_INFO                                                     \
         _IOR(DATTO_IOCTL_MAGIC, 8, struct dattobd_info) // in: see above
 #define IOCTL_GET_FREE _IOR(DATTO_IOCTL_MAGIC, 9, int)
+#define IOCTL_EXTEND_COW                                                       \
+        _IOW(DATTO_IOCTL_MAGIC, 10, struct extend_cow_params) // in: see above
 
 #endif /* DATTOBD_H_ */

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -1356,9 +1356,11 @@ struct dattobd_mutable_file* dattobd_mutable_file_wrap(struct file* filp){
 
         atomic_set(&dfilp->writers, 0);
 
+        igrab(dfilp->inode);
         if((~dfilp->inode->i_flags) & S_IMMUTABLE){
                 dfilp->inode->i_flags |= S_IMMUTABLE;
         }
+        iput(dfilp->inode);
 
         return dfilp;
 error:

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -37,7 +37,7 @@ static int kern_path(const char *name, unsigned int flags, struct path *path)
 /**
  * dattobd_kernel_read() - This is a wrapper around kernel_read enhanced for
  * systems that don't support it.
- * @filp: A &struct file object.
+ * @dfilp: A dattobd mutable file object.
  * @buf: A buffer with at least @count entries.
  * @count: The number of bytes to read from @filp.
  * @pos: Set to the offset into @filp identifying the first sequential access.
@@ -45,29 +45,27 @@ static int kern_path(const char *name, unsigned int flags, struct path *path)
  *
  * Return: The number of bytes read or a negative errno.
  */
-static ssize_t dattobd_kernel_read(struct file *filp, struct snap_device* dev, void *buf, size_t count,
+static ssize_t dattobd_kernel_read(struct dattobd_mutable_file *dfilp, struct snap_device* dev, void *buf, size_t count,
                                    loff_t *pos)
 {
         ssize_t ret;
 
-        if(filp){
+        if(dfilp){
+                // no need for making file mutable at read?
+                dattobd_mutable_file_unlock(dfilp);
 #ifndef HAVE_KERNEL_READ_PPOS
-        //#if LINUX_VERSION_CODE < KERNEL_VERSION(4,14,0)
-        mm_segment_t old_fs;
-        file_unlock(filp);
-
-        old_fs = get_fs();
-        set_fs(get_ds());
-        ret = vfs_read(filp, (char __user *)buf, count, pos);
-        set_fs(old_fs);
-        file_lock(filp);
-        return ret;
+                //#if LINUX_VERSION_CODE < KERNEL_VERSION(4,14,0)
+                mm_segment_t old_fs;
+                old_fs = get_fs();
+                set_fs(get_ds());
+                ret = vfs_read(dfilp->filp, (char __user *)buf, count, pos);
+                set_fs(old_fs);
+                return ret;
 #else
-        file_unlock(filp);
-        ret=kernel_read(filp, buf, count, pos);
-        file_lock(filp);
-        return ret;
+                ret=kernel_read(dfilp->filp, buf, count, pos);
 #endif
+                dattobd_mutable_file_lock(dfilp);
+                return ret;
         }else{
 		LOG_DEBUG("DIO: reading %lu sectors...", count / SECTOR_SIZE);
 
@@ -81,7 +79,7 @@ static ssize_t dattobd_kernel_read(struct file *filp, struct snap_device* dev, v
 /**
  * dattobd_kernel_write() - This is a wrapper around kernel_write enhanced for
  * systems that don't support it.
- * @filp: A &struct file object.
+ * @dfilp: A dattobd mutable file object.
  * @buf: A buffer with at least @count entries.
  * @count: The number of bytes to write to @filp.
  * @pos: Set to the offset into @filp identifying the first sequential access.
@@ -89,28 +87,26 @@ static ssize_t dattobd_kernel_read(struct file *filp, struct snap_device* dev, v
  *
  * Return: The number of bytes written or a negative errno.
  */
-static ssize_t dattobd_kernel_write(struct file *filp,struct snap_device* dev, const void *buf,
+static ssize_t dattobd_kernel_write(struct dattobd_mutable_file *dfilp, struct snap_device* dev, const void *buf,
                                     size_t count, loff_t *pos)
 {
         ssize_t ret;
 
-        if(filp){
+        if(dfilp){
+                dattobd_mutable_file_unlock(dfilp);
 #ifndef HAVE_KERNEL_WRITE_PPOS
-        //#if LINUX_VERSION_CODE < KERNEL_VERSION(4,14,0)
-        mm_segment_t old_fs;
+                //#if LINUX_VERSION_CODE < KERNEL_VERSION(4,14,0)
+                mm_segment_t old_fs;
 
-        old_fs = get_fs();
-        set_fs(get_ds());
-        ret = vfs_write(filp, (__force const char __user *)buf, count, pos);
-        set_fs(old_fs);
-
-        return ret;
+                old_fs = get_fs();
+                set_fs(get_ds());
+                ret = vfs_write(dfilp->filp, (__force const char __user *)buf, count, pos);
+                set_fs(old_fs);
 #else
-        file_unlock(filp);
-        ret= kernel_write(filp, buf, count, pos);
-        file_lock(filp);
-        return ret;
+                ret = kernel_write(dfilp->filp, buf, count, pos);
 #endif
+                dattobd_mutable_file_lock(dfilp);
+                return ret;
         }else{
 		LOG_DEBUG("DIO: writing %lu sectors...", count / SECTOR_SIZE);
 
@@ -124,7 +120,8 @@ static ssize_t dattobd_kernel_write(struct file *filp,struct snap_device* dev, c
 /**
  * file_io() - Reads or writes to the supplied file.
  *
- * @cm: A pointer to the cow manager
+ * @dfilp: A dattobd mutable file object.
+ * @dev: The snap device object, where file is located.
  * @is_write: An integer encoded bool indicating a write or read operation.
  * @buf: Input/output buffer for write/read, respectively.
  * @offset: Byte offset of the first sequential access within @filp.
@@ -135,7 +132,7 @@ static ssize_t dattobd_kernel_write(struct file *filp,struct snap_device* dev, c
  * * 0 - success
  * * !0 - errno indicating the error
  */
-int file_io(struct file *filp, struct snap_device* dev, int is_write, void *buf, sector_t offset,
+int file_io(struct dattobd_mutable_file *dfilp, struct snap_device* dev, int is_write, void *buf, sector_t offset,
             unsigned long len, unsigned long *done)
 {
         ssize_t ret;
@@ -145,9 +142,9 @@ int file_io(struct file *filp, struct snap_device* dev, int is_write, void *buf,
                 *done = 0;
 
         if (is_write)
-                ret = dattobd_kernel_write(filp, dev, buf, len, &off);
+                ret = dattobd_kernel_write(dfilp, dev, buf, len, &off);
         else
-                ret = dattobd_kernel_read(filp, dev, buf, len, &off);
+                ret = dattobd_kernel_read(dfilp, dev, buf, len, &off);
 
         if (unlikely(ret < 0)) {
                 LOG_ERROR((int)ret, "error performing file '%s': %llu, %lu",
@@ -171,45 +168,22 @@ int file_io(struct file *filp, struct snap_device* dev, int is_write, void *buf,
         return ret;
 }
 
-/**
- * file_write() - Writes @len bytes of data to offset @offset within @filp from
- * @buf.
- *
- * @cm: A pointer to the cow manager object.
- * @buf: Input buffer for write.
- * @offset: Byte offset of the first sequential access within @filp.
- * @len: The number of bytes in the transfer.
- *
- * Return:
- * * 0 - success
- * * !0 - errno indicating the error
- */
-//#define file_write(filp, dev, buf, offset, len) file_io(filp, dev, 1, buf, offset, len)
+inline void file_close(struct dattobd_mutable_file *dfilp){
+        // force closing dattobd_mutable_file
+        if(unlikely(!dfilp))
+                return;
+        if(atomic_read(&dfilp->writers) > 0){
+                LOG_WARN("closing file that is still unlocked");
+        }
+        dattobd_mutable_file_unlock(dfilp);
+        __file_close_raw(dfilp->filp);
+}
 
-/**
- * file_read() - Store @len bytes of data from offset @offset within @filp into
- * @buf.
- *
- * @cm: A pointer to the cow manager object.
- * @buf: Output buffer for read.
- * @offset: Byte offset of the first sequential access within @filp.
- * @len: The number of bytes in the transfer.
- *
- * Return:
- * * 0 - success
- * * !0 - errno indicating the error
- */
-//#define file_read(filp, dev, buf, offset, len) file_io(filp, dev, 0, buf, offset, len)
-
-/**
- * file_close() - Closes the file object.
- *
- * @f: A pointer to a file object.
- */
-inline void file_close(struct file *f)
-{
-        file_unlock_mark_dirty(f);
-        filp_close(f, NULL);
+inline void __file_close_raw(struct file *filp){
+        if(unlikely(!filp))
+                return;
+        mark_inode_dirty(dattobd_get_dentry(filp)->d_inode);
+        filp_close(filp, NULL);
 }
 
 /**
@@ -254,7 +228,7 @@ int file_open(const char *filename, int flags, struct file **filp)
 error:
         LOG_ERROR(ret, "error opening file");
         if (f)
-                file_close(f);
+                __file_close_raw(f);
 
         *filp = NULL;
         return ret;
@@ -666,7 +640,8 @@ static int dattobd_do_truncate(struct dentry *dentry, loff_t length,
                 newattrs.ia_valid |= ret | ATTR_FORCE;
 
         dattobd_inode_lock(dentry->d_inode);
-        inode_attr_unlock(dentry->d_inode);
+        // replaced with dattobd_mutable_file lock/unlock mechanism
+        // inode_attr_unlock(dentry->d_inode);
 #ifdef HAVE_NOTIFY_CHANGE_2
         //#if LINUX_VERSION_CODE < KERNEL_VERSION(3,13,0)
         ret = notify_change(dentry, &newattrs);
@@ -678,7 +653,7 @@ static int dattobd_do_truncate(struct dentry *dentry, loff_t length,
 #else
         ret = notify_change(dentry, &newattrs, NULL);
 #endif
-        inode_attr_lock(dentry->d_inode);
+        // inode_attr_lock(dentry->d_inode);
         dattobd_inode_unlock(dentry->d_inode);
 
         return ret;
@@ -687,7 +662,7 @@ static int dattobd_do_truncate(struct dentry *dentry, loff_t length,
 /**
  * file_truncate() - Truncates a file to a given length.
  *
- * @filp: A &struct file object.
+ * @dfilp: A dattobd mutable file object.
  * @len: The truncation length in bytes.
  *
  * Special treatment of SUID and SGID is performed.  See @dattobd_do_truncate.
@@ -696,26 +671,30 @@ static int dattobd_do_truncate(struct dentry *dentry, loff_t length,
  * * 0 - success
  * * !0 - errno indicating the error.
  */
-int file_truncate(struct file *filp, loff_t len)
+int file_truncate(struct dattobd_mutable_file *dfilp, loff_t len)
 {
         struct inode *inode;
         struct dentry *dentry;
         int ret;
 
-        dentry = dattobd_get_dentry(filp);
-        inode = dentry->d_inode;
+        dentry = dfilp->dentry;
+        inode = dfilp->inode;
+
+        dattobd_mutable_file_unlock(dfilp);
 
 #ifdef HAVE_SB_START_WRITE
         //#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0)
         sb_start_write(inode->i_sb);
 #endif
 
-        ret = dattobd_do_truncate(dentry, len, ATTR_MTIME | ATTR_CTIME, filp);
+        ret = dattobd_do_truncate(dentry, len, ATTR_MTIME | ATTR_CTIME, dfilp->filp);
 
 #ifdef HAVE_SB_START_WRITE
         //#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0)
         sb_end_write(inode->i_sb);
 #endif
+
+        dattobd_mutable_file_lock(dfilp);
 
         if (ret) {
                 LOG_ERROR(ret, "error performing truncation");
@@ -808,7 +787,8 @@ static int real_fallocate(struct file *f, uint64_t offset, uint64_t length)
  * within the range specified by @offset and @length.  Attempts to use
  * @real_fallocate with a fallback of writing zeroes if that fails.
  *
- * @cm: A &struct cow_manager object.
+ * @dfilp: A dattobd mutable file object.
+ * @dev: The snap device object, where file is located.
  * @offset: The offset into @f indicating the start of the allocation.
  * @length: The number of byte to allocate starting at @offset.
  * @done: Pointer to store the number of bytes allocated or NULL if not needed.
@@ -817,7 +797,7 @@ static int real_fallocate(struct file *f, uint64_t offset, uint64_t length)
  * * 0 - success
  * * !0 - errno indicating the error.
  */
-int file_allocate(struct file *filp, struct snap_device* dev,  uint64_t offset, uint64_t length, uint64_t *done)
+int file_allocate(struct dattobd_mutable_file *dfilp, struct snap_device* dev,  uint64_t offset, uint64_t length, uint64_t *done)
 {
         int ret = 0;
         char *page_buf = NULL;
@@ -826,7 +806,7 @@ int file_allocate(struct file *filp, struct snap_device* dev,  uint64_t offset, 
         int abs_path_len;
         unsigned long cur_done;
 
-        file_get_absolute_pathname(filp, &abs_path, &abs_path_len);
+        file_get_absolute_pathname(dfilp->filp, &abs_path, &abs_path_len);
 
         // allocate page of zeros
         page_buf = (char *)get_zeroed_page(GFP_KERNEL);
@@ -844,7 +824,7 @@ int file_allocate(struct file *filp, struct snap_device* dev,  uint64_t offset, 
 
         // if not page aligned, write zeros to that point
         if (offset % PAGE_SIZE != 0) {
-                ret = file_write(filp, dev, page_buf, offset,
+                ret = file_write(dfilp, dev, page_buf, offset,
                                  PAGE_SIZE - (offset % PAGE_SIZE), &cur_done);
                 if (done)
                         *done += cur_done;
@@ -856,14 +836,15 @@ int file_allocate(struct file *filp, struct snap_device* dev,  uint64_t offset, 
 
         // write a page of zeros at a time
         for (i = 0; i < write_count; i++) {
-                ret = file_write(filp, dev, page_buf, offset + (PAGE_SIZE * i),
+                ret = file_write(dfilp, dev, page_buf, offset + (PAGE_SIZE * i),
                                  PAGE_SIZE, &cur_done);
                 if (done)
                         *done += cur_done;
                 if (ret)
                         goto error;
         }
-        file_lock(filp);
+
+        // removed locking as it is managed by the lower level functions
 
 out:
         if (page_buf)
@@ -891,7 +872,7 @@ error:
 
 /**
  * __file_unlink() - delete a name and possibly the file it refers to.
- * @filp: A &struct file object.
+ * @dfilp: A dataobd mutable file object.
  * @close: Close the @filp on success.
  * @force: Always close the @filp regardless of a successful unlink.
  *
@@ -899,20 +880,21 @@ error:
  * * 0 - success
  * * !0 - errno indicating the error.
  */
-int __file_unlink(struct file *filp, int close, int force)
+int __file_unlink(struct dattobd_mutable_file *dfilp, int close, int force)
 {
         int ret = 0;
-        struct inode *dir_inode = dattobd_get_dentry(filp)->d_parent->d_inode;
-        struct dentry *file_dentry = dattobd_get_dentry(filp);
-        struct vfsmount *mnt = dattobd_get_mnt(filp);
+        struct inode *dir_inode = dfilp->dentry->d_parent->d_inode;
+        struct dentry *file_dentry = dfilp->dentry;
+        struct vfsmount *mnt = dattobd_get_mnt(dfilp->filp);
 
-        if(file_dentry->d_inode && inode_attr_is_locked(file_dentry->d_inode)){
-                inode_attr_unlock(file_dentry->d_inode);
-        }
+        // replaced with dattobd_mutable_file lock/unlock mechanism
+        // if(file_dentry->d_inode && inode_attr_is_locked(file_dentry->d_inode)){
+        //         inode_attr_unlock(file_dentry->d_inode);
+        // }
 
         if (d_unlinked(file_dentry)) {
                 if (close)
-                        file_close(filp);
+                        file_close(dfilp);
                 return 0;
         }
 
@@ -924,6 +906,8 @@ int __file_unlink(struct file *filp, int close, int force)
                 LOG_ERROR(ret, "error getting write access to vfs mount");
                 goto mnt_error;
         }
+
+        dattobd_mutable_file_unlock(dfilp);
 
 #ifdef HAVE_VFS_UNLINK_2
         //#if LINUX_VERSION_CODE < KERNEL_VERSION(3,13,0)
@@ -945,7 +929,7 @@ error:
         mnt_drop_write(mnt);
 
         if (close && (!ret || force))
-                file_close(filp);
+                file_close(dfilp);
 
 mnt_error:
         iput(dir_inode);
@@ -1078,27 +1062,28 @@ void dattobd_mm_unlock(struct mm_struct* mm)
 #endif
 }
 
-void file_switch_lock(struct file* filp, bool lock, bool mark_dirty)
-{
-        struct inode* inode;
+// removed file_switch_lock as it is managed by the dattobd_mutable_file
+// void file_switch_lock(struct file* filp, bool lock, bool mark_dirty)
+// {
+//         struct inode* inode;
 
-        if(!filp) return;
+//         if(!filp) return;
 
-        inode= dattobd_get_dentry(filp)->d_inode;
-        igrab(inode);
+//         inode= dattobd_get_dentry(filp)->d_inode;
+//         igrab(inode);
 
-        if(lock){
-                inode_attr_lock(inode);
-        }else{
-                inode_attr_unlock(inode);
-        }
+//         if(lock){
+//                 inode->i_flags |= S_IMMUTABLE;
+//         }else{
+//                 inode->i_flags &= ~S_IMMUTABLE;
+//         }
 
-        if(mark_dirty){
-                mark_inode_dirty(inode);
-        }
+//         if(mark_dirty){
+//                 mark_inode_dirty(inode);
+//         }
 
-        iput(inode);
-}
+//         iput(inode);
+// }
 
 int file_write_block(struct snap_device* dev, const void* block, size_t offset, size_t len)
 {
@@ -1331,4 +1316,77 @@ sector_t sector_by_offset(struct snap_device*dev, size_t offset)
 	return SECTOR_INVALID;
 }
 
+struct dattobd_mutable_file* dattobd_mutable_file_wrap(struct file* filp){
+        struct dattobd_mutable_file *dfilp = kzalloc(sizeof(struct dattobd_mutable_file), GFP_KERNEL);
+        long ret;
 
+        if(unlikely(!dfilp)){
+                LOG_ERROR(-ENOMEM, "error allocating dattobd mutable file");
+                return ERR_PTR(-ENOMEM);
+        }
+
+        dfilp->filp = filp;
+        dfilp->dentry = dattobd_get_dentry(filp);
+
+        if(unlikely(IS_ERR(dfilp->dentry))){
+                LOG_ERROR((int)PTR_ERR(dfilp->dentry), "error getting dentry from file");
+                ret = PTR_ERR(dfilp->dentry);
+                goto error;
+        }
+
+        if(unlikely(!dfilp->dentry)){
+                LOG_ERROR(-ENOENT, "error getting dentry from file, dentry is absent");
+                ret = -ENOENT;
+                goto error;
+        }
+
+        dfilp->inode = dfilp->dentry->d_inode;
+
+        if(unlikely(IS_ERR(dfilp->inode))){
+                LOG_ERROR((int)PTR_ERR(dfilp->inode), "error getting inode from dentry");
+                ret = PTR_ERR(dfilp->inode);
+                goto error;
+        }
+
+        if(unlikely(!dfilp->inode)){
+                LOG_ERROR(-ENOENT, "error getting inode from dentry, inode is absent");
+                ret = -ENOENT;
+                goto error;
+        }
+
+        atomic_set(&dfilp->writers, 0);
+
+        if((~dfilp->inode->i_flags) & S_IMMUTABLE){
+                dfilp->inode->i_flags |= S_IMMUTABLE;
+        }
+
+        return dfilp;
+error:
+        kfree(dfilp);
+        return ERR_PTR(ret);
+}
+
+void dattobd_mutable_file_unlock(struct dattobd_mutable_file* dfilp){
+        if(dfilp){
+                igrab(dfilp->inode);
+                dfilp->inode->i_flags &= ~S_IMMUTABLE;
+                iput(dfilp->inode);
+                atomic_inc(&dfilp->writers);
+        }
+}
+
+void dattobd_mutable_file_lock(struct dattobd_mutable_file* dfilp){
+        if(dfilp){
+                if(atomic_dec_and_test(&dfilp->writers)){
+                        igrab(dfilp->inode);
+                        dfilp->inode->i_flags |= S_IMMUTABLE;
+                        iput(dfilp->inode);
+                }
+        }
+}
+
+void dattobd_mutable_file_unwrap(struct dattobd_mutable_file* dfilp){
+        if(dfilp){
+                kfree(dfilp);
+        }
+}

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -66,6 +66,7 @@ struct dattobd_mutable_file {
         struct file *filp;
         struct dentry *dentry;
         struct inode *inode;
+        struct vfsmount *mnt;
         
         atomic_t writers;
 };
@@ -113,7 +114,7 @@ int dentry_get_relative_pathname(struct dentry *dentry, char **buf,
                                  int *len_res);
 #endif
 
-int file_get_absolute_pathname(const struct file *filp, char **buf,
+int file_get_absolute_pathname(const struct dattobd_mutable_file *dfilp, char **buf,
                                int *len_res);
 
 int pathname_to_absolute(const char *pathname, char **buf, int *len_res);

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -23,14 +23,15 @@
 #define file_unlink_and_close(filp) __file_unlink(filp, 1, 0)
 #define file_unlink_and_close_force(filp) __file_unlink(filp, 1, 1)
 
-#define file_lock(filp) file_switch_lock(filp, true, false)
-#define file_unlock(filp) file_switch_lock(filp, false, false)
-#define file_unlock_mark_dirty(filp) file_switch_lock(filp, false, true)
+// #define file_lock(filp) file_switch_lock(filp, true, false)
+// #define file_unlock(filp) file_switch_lock(filp, false, false)
+// #define file_unlock_mark_dirty(filp) file_switch_lock(filp, false, true)
 
+// replaced with dattobd_mutable_file lock/unlock mechanism
 // INODE Attribute Locking is based on the S_IMMUTABLE flag
-#define inode_attr_is_locked(inode) ( (inode->i_flags) & S_IMMUTABLE )
-#define inode_attr_lock(inode) do{ inode->i_flags |= S_IMMUTABLE; } while(0)
-#define inode_attr_unlock(inode) do{ inode->i_flags &= ~S_IMMUTABLE; } while(0)
+// #define inode_attr_is_locked(inode) ( (inode->i_flags) & S_IMMUTABLE )
+// #define inode_attr_lock(inode) do{ inode->i_flags |= S_IMMUTABLE; } while(0)
+// #define inode_attr_unlock(inode) do{ inode->i_flags &= ~S_IMMUTABLE; } while(0)
 
 #ifndef HAVE_STRUCT_PATH
 //#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,20)
@@ -61,6 +62,22 @@ struct file;
 struct dentry;
 struct vfsmount;
 
+struct dattobd_mutable_file {
+        struct file *filp;
+        struct dentry *dentry;
+        struct inode *inode;
+        
+        atomic_t writers;
+};
+
+struct dattobd_mutable_file* dattobd_mutable_file_wrap(struct file*);
+
+void dattobd_mutable_file_unlock(struct dattobd_mutable_file*);
+
+void dattobd_mutable_file_lock(struct dattobd_mutable_file*);
+
+void dattobd_mutable_file_unwrap(struct dattobd_mutable_file*);
+
 #ifndef HAVE_STRUCT_PATH
 //#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,20)
 struct path {
@@ -73,12 +90,20 @@ struct path {
 typedef mode_t fmode_t;
 #endif
 
-int file_io(struct file *filp, struct snap_device* dev, int is_write, void *buf, sector_t offset,
+int file_open(const char *filename, int flags, struct file **filp);
+
+int file_io(struct dattobd_mutable_file *dfilp, struct snap_device* dev, int is_write, void *buf, sector_t offset,
             unsigned long len, unsigned long *done);
 
-void file_close(struct file *f);
+int file_truncate(struct dattobd_mutable_file *dfilp, loff_t len);
 
-int file_open(const char *filename, int flags, struct file **filp);
+int file_allocate(struct dattobd_mutable_file *dfilp, struct snap_device* dev, uint64_t offset, uint64_t length, uint64_t *done);
+
+int __file_unlink(struct dattobd_mutable_file* dfilp, int close, int force);
+
+void file_close(struct dattobd_mutable_file *filp);
+
+void __file_close_raw(struct file *dfilp);
 
 #if !defined(HAVE___DENTRY_PATH) && !defined(HAVE_DENTRY_PATH_RAW)
 int dentry_get_relative_pathname(struct dentry *dentry, char **buf,
@@ -98,12 +123,6 @@ int pathname_concat(const char *pathname1, const char *pathname2,
 
 int user_mount_pathname_concat(const char __user *user_mount_path,
                                const char *rel_path, char **path_out);
-
-int file_truncate(struct file *filp, loff_t len);
-
-int file_allocate(struct file *filp, struct snap_device* dev, uint64_t offset, uint64_t length, uint64_t *done);
-
-int __file_unlink(struct file *filp, int close, int force);
 
 #ifndef HAVE_NOOP_LLSEEK
 //#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,35)
@@ -132,8 +151,6 @@ void dattobd_vm_area_free(struct vm_area_struct *vma);
 void dattobd_mm_lock(struct mm_struct* mm);
 
 void dattobd_mm_unlock(struct mm_struct* mm);
-
-void file_switch_lock(struct file* filp, bool lock, bool mark_dirty);
 
 int file_write_block(struct snap_device* dev, const void* block, size_t offset, size_t len);
 

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -11,8 +11,13 @@
 #include "userspace_copy_helpers.h"
 #include "snap_device.h"
 
-#define file_write(filp, dev, buf, offset, len) file_io(filp, dev, 1, buf, offset, len)
-#define file_read(filp, dev, buf, offset, len) file_io(filp, dev, 0, buf, offset, len)
+#define file_read(filp, dev, buf, offset, len) file_io(filp, dev, 0, buf, offset, len, NULL)
+
+#define file_write5(filp, dev, buf, offset, len) file_io(filp, dev, 1, buf, offset, len, NULL)
+#define file_write6(filp, dev, buf, offset, len, done) file_io(filp, dev, 1, buf, offset, len, done)
+
+#define _get_macro(_1,_2,_3,_4,_5,_6,NAME,...) NAME
+#define file_write(...) _get_macro(__VA_ARGS__, file_write6, file_write5)(__VA_ARGS__)
 
 #define file_unlink(filp) __file_unlink(filp, 0, 0)
 #define file_unlink_and_close(filp) __file_unlink(filp, 1, 0)
@@ -69,7 +74,7 @@ typedef mode_t fmode_t;
 #endif
 
 int file_io(struct file *filp, struct snap_device* dev, int is_write, void *buf, sector_t offset,
-            unsigned long len);
+            unsigned long len, unsigned long *done);
 
 void file_close(struct file *f);
 
@@ -96,7 +101,7 @@ int user_mount_pathname_concat(const char __user *user_mount_path,
 
 int file_truncate(struct file *filp, loff_t len);
 
-int file_allocate(struct file *filp, struct snap_device* dev, uint64_t offset, uint64_t length);
+int file_allocate(struct file *filp, struct snap_device* dev, uint64_t offset, uint64_t length, uint64_t *done);
 
 int __file_unlink(struct file *filp, int close, int force);
 

--- a/src/ioctl_handlers.c
+++ b/src/ioctl_handlers.c
@@ -430,7 +430,7 @@ int ioctl_expand_cow_file(unsigned int minor, unsigned long size)
                 goto error;
         }
 
-        ret = cow_expand_datastore(dev, size);
+        ret = cow_expand_datastore(dev->sd_cow, size);
 
         if(ret)
                 goto error;

--- a/src/ioctl_handlers.c
+++ b/src/ioctl_handlers.c
@@ -408,7 +408,7 @@ int ioctl_expand_cow_file(unsigned int minor, unsigned long size)
         LOG_DEBUG("received expand cow file ioctl - %u : %lu", minor, size);
 
         // verify that the minor number is valid
-        ret = verify_minor_in_use_not_busy(minor);
+        ret = verify_minor_in_use(minor);
         if (ret)
                 goto error;
 

--- a/src/ioctl_handlers.c
+++ b/src/ioctl_handlers.c
@@ -414,23 +414,7 @@ int ioctl_expand_cow_file(unsigned int minor, unsigned long size)
 
         dev = snap_devices[minor];
 
-        // check that the device is not in the fail state
-        if (tracer_read_fail_state(dev)) {
-                ret = -EINVAL;
-                LOG_ERROR(ret, "device specified is in the fail state");
-                goto error;
-        }
-
-        // check that tracer is in active snapshot state
-        if (!test_bit(SNAPSHOT, &dev->sd_state) ||
-            !test_bit(ACTIVE, &dev->sd_state)) {
-                ret = -EINVAL;
-                LOG_ERROR(ret,
-                          "device specified is not in active snapshot mode");
-                goto error;
-        }
-
-        ret = cow_expand_datastore(dev->sd_cow, size);
+        ret = tracer_expand_cow_file(dev, size);
 
         if(ret)
                 goto error;

--- a/src/proc_seq_file.c
+++ b/src/proc_seq_file.c
@@ -184,7 +184,7 @@ static int dattobd_proc_show(struct seq_file *m, void *v)
                         if (dev->sd_cow) {
                                 int i;
                                 seq_printf(m, "\t\t\t\"cow_size_current\": %llu,\n",
-                                   (unsigned long long)dev->sd_cow->file_max);
+                                   (unsigned long long)dev->sd_cow->file_size);
 
                                 seq_printf(
                                         m, "\t\t\t\"seq_id\": %llu,\n",

--- a/src/proc_seq_file.c
+++ b/src/proc_seq_file.c
@@ -183,6 +183,9 @@ static int dattobd_proc_show(struct seq_file *m, void *v)
 
                         if (dev->sd_cow) {
                                 int i;
+                                seq_printf(m, "\t\t\t\"cow_size_current\": %llu,\n",
+                                   (unsigned long long)dev->sd_cow->file_max);
+
                                 seq_printf(
                                         m, "\t\t\t\"seq_id\": %llu,\n",
                                         (unsigned long long)dev->sd_cow->seqid);

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -2470,7 +2470,7 @@ int tracer_expand_cow_file(struct snap_device *dev, uint64_t size){
         if(ret){
                 LOG_ERROR(ret, "error expanding cow file");
                 tracer_set_fail_state(dev, ret);
-                __tracer_destroy_cow_thread(dev);
+                // __tracer_destroy_cow_thread(dev); -- we can't ask for thread destroy, as this function may be called from cow thread
                 // cow_thread must fail in a few moments
         }
 

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -661,7 +661,7 @@ static int __tracer_setup_cow(struct snap_device *dev,
                         if (ret)
                                 goto error;
 
-                        dev->sd_falloc_size = dev->sd_cow->file_max;
+                        dev->sd_falloc_size = dev->sd_cow->file_size;
                         do_div(dev->sd_falloc_size, (1024 * 1024));
                 }
         }
@@ -2153,7 +2153,7 @@ void tracer_dattobd_info(const struct snap_device *dev,
         strlcpy(info->bdev, dev->sd_bdev_path, PATH_MAX);
 
         if (!test_bit(UNVERIFIED, &dev->sd_state)) {
-                info->falloc_size = dev->sd_cow->file_max;
+                info->falloc_size = dev->sd_cow->file_size;
                 info->seqid = dev->sd_cow->seqid;
                 memcpy(info->uuid, dev->sd_cow->uuid, COW_UUID_SIZE);
                 info->version = dev->sd_cow->version;

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -2445,21 +2445,6 @@ error:
 int tracer_expand_cow_file(struct snap_device *dev, uint64_t size){
         int ret;
         LOG_DEBUG("ENTER tracer_expand_cow_file");
-        if(test_bit(UNVERIFIED, &dev->sd_state)){
-                LOG_ERROR(-EINVAL, "cannot expand cow file for unverified device");
-                return -EINVAL;
-        }
-
-        if(!test_bit(ACTIVE, &dev->sd_state)){
-                LOG_ERROR(-EBUSY, "cannot expand cow file for inactive device");
-                return -EBUSY;
-        }
-
-        if(!test_bit(SNAPSHOT, &dev->sd_state)){
-                LOG_ERROR(-EINVAL, "cow expansion not supported for incremental mode");
-                return -EINVAL;
-        }
-
         if(tracer_read_fail_state(dev)){
                 LOG_ERROR(-EBUSY, "cannot expand cow file for device in error state");
                 return -EBUSY;

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -52,6 +52,8 @@ void tracer_reconfigure(struct snap_device *dev, unsigned long cache_size);
 void tracer_dattobd_info(const struct snap_device *dev,
                          struct dattobd_info *info);
 
+int tracer_expand_cow_file(struct snap_device *dev, uint64_t size);
+
 /************************AUTOMATIC TRANSITION FUNCTIONS************************/
 
 void __tracer_active_to_dormant(struct snap_device *dev);


### PR DESCRIPTION
# Purpose
Add an ability to increase COW-file in during active snapshot mode in manual way (using `ioctl` or procedure).

# What was done
- Added procedure to increase COW-file with a new pages.
- Added `ioctl` call to execute the procedure -- `expand_cow_file(unsigned int minor, unsigned long size)`.
- Updated `dbdctl` and `libdattobd.h` with new `ioctl` call.
- Updated the documentation with the new `ioctl` call.
- Updated `/proc/datto-info` to show current COW-file size. (field `cow_size_current`).
- Replaced `S_IMMUTABLE` locking mechanism with a new `struct dattobd_mutable_file`, which controls mutability and counts active references using `atomic_t`, which prevents us from race conditions (trying to write to immutable file).
- Replaced usage of raw `struct file*` with `struct dattobd_mutable_file*` where possible.
- Truncation of COW-file now updates actual COW-file size in code.

