### PR TITLE
[FEATURE] COW-file Auto-Expand

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ The current status of the dattobd driver can be read from the file `/proc/datto-
 * `cow_size_current`: The current size of the cow file (in bytes). This will not be printed if the device is in the unverified state.
 * `seq_id`: The sequence id of the snapshot. This number starts at 1 for new snapshots and is incremented on each transition to snapshot.
 * `uuid`: Uniquely identifies a series of snapshots. It is not changed on state transition.
+* `auto_expand`: Parameters of auto-expansion of COW-file.
+    * `step_size`: Expansion step size (in bytes)
+    * `steps`: Steps the DattoBD allowed to do (-1 if unlimited).
 * `error`: This field will only be present if the device has failed. It shows the linux standard error code indicating what went wrong. More specific info is printed to dmesg.
 * `state`: An integer representing the current working state of the device. There are 6 possible states; for more info on these refer to [STRUCTURE.md](doc/STRUCTURE.md).
 	* 0 = dormant incremental

--- a/app/bash_completion.d/dbdctl
+++ b/app/bash_completion.d/dbdctl
@@ -4,7 +4,7 @@ _dbdctl()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="setup-snapshot reload-snapshot reload-incremental destroy transition-to-incremental transition-to-snapshot reconfigure expand-cow-file help"
+    opts="setup-snapshot reload-snapshot reload-incremental destroy transition-to-incremental transition-to-snapshot reconfigure expand-cow-file reconfigure-auto-expand help"
 
     if [[ ${cur} == * ]] ; then
         COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )

--- a/doc/dbdctl.8
+++ b/doc/dbdctl.8
@@ -80,6 +80,12 @@ Allows you to reconfigure various parameters of a snapshot while it is online\. 
 .P
 Expands cow file in snapshot mode by size (given in bytes)\.
 .
+.SS "reconfigure-auto-expand"
+\fBdbdctl reconfigure-auto-expand [-n <steps limit>] <step size> <minor>\fR
+.
+.P
+Enable auto-expand of cow file in snapshot mode by <step size> (given in bytes), limited with <steps limit> steps (or -1 if unlimited)\.
+.
 .SS "EXAMPLES"
 \fB# dbdctl setup\-snapshot /dev/sda1 /var/backup/datto 4\fR
 .

--- a/doc/dbdctl.8.html
+++ b/doc/dbdctl.8.html
@@ -146,6 +146,12 @@
 
 <p>Expands cow file in snapshot mode by size (given in bytes).</p>
 
+<h3 id="reconfigure-auto-expand">reconfigure-auto-expand</h3>
+
+<p><code>dbdctl reconfigure-auto-expand [-n &lt;steps limit&gt;] &lt;step size&gt; &lt;minor&gt;</code></p>
+
+<p>Enable auto-expand of cow file in snapshot mode by &lt;step size&gt; (given in bytes), limited with &lt;steps limit&gt; steps (or -1 if unlimited).</p>
+
 <h3 id="EXAMPLES">EXAMPLES</h3>
 
 <p><code># dbdctl setup-snapshot /dev/sda1 /var/backup/datto 4</code></p>

--- a/doc/dbdctl.8.md
+++ b/doc/dbdctl.8.md
@@ -69,6 +69,12 @@ Allows you to reconfigure various parameters of a snapshot while it is online. C
 
 Expands cow file in snapshot mode by size (given in bytes).
 
+### reconfigure-auto-expand
+
+`dbdctl reconfigure-auto-expand [-n <steps limit>] <step size> <minor>`
+
+Enable auto-expand of cow file in snapshot mode by <step size> (given in bytes), limited with <steps limit> steps (or -1 if unlimited).
+
 ### EXAMPLES
 
 `# dbdctl setup-snapshot /dev/sda1 /var/backup/datto 4`

--- a/lib/libdattobd.c
+++ b/lib/libdattobd.c
@@ -169,3 +169,19 @@ int dattobd_expand_cow_file(unsigned int minor, unsigned long size){
 	close(fd);
 	return ret;
 }
+
+int dattobd_reconfigure_auto_expand(unsigned int minor, uint64_t step_size, long steps){
+	int fd, ret;
+	struct reconfigure_auto_expand_params params;
+	params.minor=minor;
+	params.step_size=step_size;
+	params.steps=steps;
+
+	fd = open("/dev/datto-ctl", O_RDONLY);
+	if(fd < 0) return -1;
+
+	ret = ioctl(fd, IOCTL_RECONFIGURE_AUTO_EXPAND, &params);
+
+	close(fd);
+	return ret;
+}

--- a/lib/libdattobd.h
+++ b/lib/libdattobd.h
@@ -31,6 +31,8 @@ int dattobd_info(unsigned int minor, struct dattobd_info *info);
 
 int dattobd_expand_cow_file(unsigned int minor, unsigned long size);
 
+int dattobd_reconfigure_auto_expand(unsigned int minor, uint64_t step_size, long steps);
+
 /**
  * Get the first available minor.
  *

--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -1262,6 +1262,9 @@ uint64_t cow_auto_expand_manager_test_and_dec(struct cow_auto_expand_manager* ae
         if(aem->steps > 0){
                 aem->steps--;
                 ret = aem->step_size;
+        }else if(aem->steps == -1){
+                // infinite steps
+                ret = aem->step_size;
         }
         mutex_unlock(&aem->lock);
 

--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -1229,7 +1229,7 @@ struct cow_auto_expand_manager* cow_auto_expand_manager_init(void){
         struct cow_auto_expand_manager* aem = kzalloc(sizeof(struct cow_auto_expand_manager), GFP_KERNEL);
         if(!aem){
                 LOG_ERROR(-ENOMEM, "error allocating cow auto expand manager");
-                return NULL;
+                return ERR_PTR(-ENOMEM);
         }
 
         mutex_init(&aem->lock);

--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -7,6 +7,7 @@
 #include "cow_manager.h"
 #include "filesystem.h"
 #include "logging.h"
+#include "tracer.h"
 
 #ifdef HAVE_UUID_H
 #include <linux/uuid.h>
@@ -622,8 +623,7 @@ int cow_reload(const char *path, uint64_t elements, unsigned long sect_size,
         cm->allowed_sects =
                 __cow_calculate_allowed_sects(cache_size, cm->total_sects);
         cm->data_offset = COW_HEADER_SIZE + (cm->total_sects * (sect_size * sizeof(uint64_t)));
-        cm->auto_expand_step_size = 0;
-        cm->auto_expand_max = 0;
+        cm->auto_expand = NULL;
 
         ret = __cow_open_header(cm, index_only, 1);
         if (ret)
@@ -732,8 +732,7 @@ int cow_init(struct snap_device *dev, const char *path, uint64_t elements, unsig
         cm->data_offset = COW_HEADER_SIZE + (cm->total_sects * (sect_size * 8)); // data offset in bytes, equals 4096 + [total_sects*4096*8](index size)
         cm->curr_pos = cm->data_offset / COW_BLOCK_SIZE;
         cm->dev = dev;
-        cm->auto_expand_step_size = 0;
-        cm->auto_expand_max = 0;
+        cm->auto_expand = NULL;
 
         if (uuid)
                 memcpy(cm->uuid, uuid, COW_UUID_SIZE);
@@ -947,9 +946,23 @@ static int __cow_write_data(struct cow_manager *cm, void *buf)
         char *abs_path = NULL;
         int abs_path_len;
         uint64_t curr_size = cm->curr_pos * COW_BLOCK_SIZE;
+        uint64_t expand_allowance = 0;
 
+retry:
         if (curr_size >= cm->file_size) {
-                // TODO: expand the cow file if possible
+                // try expansion of cow_file
+                if(cm->auto_expand){
+                        expand_allowance = cow_auto_expand_manager_test_and_dec(cm->auto_expand);
+                        if(expand_allowance){
+                                ret = tracer_expand_cow_file(cm->dev, expand_allowance);
+                                expand_allowance = 0;
+                                if(ret)
+                                        goto error;
+                                goto retry;
+                        }
+                }
+
+
                 ret = -EFBIG;
 
                 file_get_absolute_pathname(cm->dfilp, &abs_path, &abs_path_len);
@@ -1194,6 +1207,8 @@ int __cow_expand_datastore(struct cow_manager* cm, uint64_t append_size){
         int ret;
         uint64_t actual = 0;
 
+        LOG_DEBUG("trying to expand cow file with %llu bytes", append_size);
+
         ret = file_allocate(cm->dfilp, cm->dev, cm->file_size, append_size, &actual);
 
         if(actual != append_size){
@@ -1208,4 +1223,52 @@ int __cow_expand_datastore(struct cow_manager* cm, uint64_t append_size){
         }
 
         return 0;
+}
+
+struct cow_auto_expand_manager* cow_auto_expand_manager_init(void){
+        struct cow_auto_expand_manager* aem = kzalloc(sizeof(struct cow_auto_expand_manager), GFP_KERNEL);
+        if(!aem){
+                LOG_ERROR(-ENOMEM, "error allocating cow auto expand manager");
+                return NULL;
+        }
+
+        mutex_init(&aem->lock);
+
+        return aem;
+}
+
+int cow_auto_expand_manager_reconfigure(struct cow_auto_expand_manager* aem, uint64_t step_size, long steps){
+        mutex_lock(&aem->lock);
+        aem->step_size = step_size;
+        aem->steps = steps;
+        mutex_unlock(&aem->lock);
+        return 0;
+}
+
+/*
+* cow_auto_expand_manager_test_and_dec() - Tests if the auto expand manager has steps remaining and decrements the steps if so.
+*
+* @aem: The &struct cow_auto_expand_manager to test and decrement.
+*
+* Return:
+* 0 - no steps remaining
+* !0 - size to expand the cow file by
+*/
+uint64_t cow_auto_expand_manager_test_and_dec(struct cow_auto_expand_manager* aem){
+        uint64_t ret;
+
+        ret = 0;
+        mutex_lock(&aem->lock);
+        if(aem->steps > 0){
+                aem->steps--;
+                ret = aem->step_size;
+        }
+        mutex_unlock(&aem->lock);
+
+        return ret;
+}
+
+void cow_auto_expand_manager_free(struct cow_auto_expand_manager* aem){
+        mutex_destroy(&aem->lock);
+        kfree(aem);
 }

--- a/src/cow_manager.h
+++ b/src/cow_manager.h
@@ -45,7 +45,7 @@ struct cow_manager {
         uint32_t flags; // flags representing current state of cow manager
         uint64_t curr_pos; // current write head position
         uint64_t data_offset; // starting offset of data
-        uint64_t file_size; // current size of the file, max size before an error is thrown
+        uint64_t file_size; // current size of the file, max size before an error is thrown or file is expanded
         uint64_t seqid; // sequence id, increments on each transition to
                         // snapshot mode
         uint64_t version; // version of cow file format
@@ -63,6 +63,10 @@ struct cow_manager {
         struct cow_section *sects; // pointer to the array of sections of
                                    // mappings
         struct snap_device* dev;  //pointer to snapshot device
+
+        // for now, auto expand settings are not preserved during reloads
+        uint64_t auto_expand_step_size; // size in bytes to expand the cow file when it is full
+        long auto_expand_max; // maximum number of times the cow file can be expanded
 };
 
 /***************************COW MANAGER FUNCTIONS**************************/

--- a/src/dattobd.h
+++ b/src/dattobd.h
@@ -51,6 +51,13 @@ struct expand_cow_file_params {
         unsigned long size; // size in bytes
 };
 
+struct reconfigure_auto_expand_params {
+        uint64_t step_size; // step size (in bytes)
+        long steps; // allowed steps (or -1 for unlimited)
+
+        unsigned int minor; // minor to configure
+};
+
 #define COW_UUID_SIZE 16
 #define COW_BLOCK_LOG_SIZE 12
 #define COW_BLOCK_SIZE (1 << COW_BLOCK_LOG_SIZE)
@@ -112,5 +119,8 @@ struct dattobd_info {
 #define IOCTL_GET_FREE _IOR(DATTO_IOCTL_MAGIC, 9, int)
 #define IOCTL_EXPAND_COW_FILE                                                  \
         _IOW(DATTO_IOCTL_MAGIC, 10, struct expand_cow_file_params) // in: see above
+#define IOCTL_RECONFIGURE_AUTO_EXPAND                                          \
+        _IOW(DATTO_IOCTL_MAGIC, 11, struct reconfigure_auto_expand_params) 
+                                                              // in: see above
 
 #endif /* DATTOBD_H_ */

--- a/src/proc_seq_file.c
+++ b/src/proc_seq_file.c
@@ -207,6 +207,15 @@ static int dattobd_proc_show(struct seq_file *m, void *v)
                                                 "%llu,\n",
                                                 dev->sd_cow->nr_changed_blocks);
                                 }
+
+                                if(dev->sd_cow->auto_expand){
+                                        seq_printf(m, "\t\t\t\"auto_expand\": {\n");
+                                        seq_printf(m, "\t\t\t\t\"step_size\": %llu,\n",
+                                                   (unsigned long long)dev->sd_cow->auto_expand->step_size);
+                                        seq_printf(m, "\t\t\t\t\"steps\": %ld\n",
+                                                   dev->sd_cow->auto_expand->steps);
+                                        seq_printf(m, "\t\t\t},\n");
+                                }
                         }
                 }
 

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -1973,6 +1973,10 @@ int tracer_active_snap_to_inc(struct snap_device *old_dev)
         // thread to prevent concurrent access.
         __tracer_destroy_cow_thread(old_dev);
 
+        // disable auto-expand
+        cow_auto_expand_manager_free(old_dev->sd_cow->auto_expand);
+        old_dev->sd_cow->auto_expand = NULL;
+
         // sanity check to ensure no errors have occurred while cleaning up the
         // old cow thread
         ret = tracer_read_fail_state(old_dev);


### PR DESCRIPTION
# Purpose
Implement an auto-expanding COW-file, which uses interfaces implemented at #2.

# What was done
- Implemented `cow_auto_expand_manager` which is responsible for storing COW-file auto-expand parameters.
- Added `ioctl` call to control `cow_auto_expand_manager` - `reconfigure_auto_expand(unsigned int minor, uint64_t stepSize, long stepsLimit)`.
- Updated `libdattobd.h` and `dbdctl` with new `ioctl` call.
- Updated documentation with new `ioctl` call.
- Updated `/proc/datto-info` to show `cow_auto_expand_manager` parameters (section `auto_expand`).