### PR TITLE
[FEATURE] [REFACTOR] Auto-Expand restrictions change

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ The current status of the dattobd driver can be read from the file `/proc/datto-
 * `seq_id`: The sequence id of the snapshot. This number starts at 1 for new snapshots and is incremented on each transition to snapshot.
 * `uuid`: Uniquely identifies a series of snapshots. It is not changed on state transition.
 * `auto_expand`: Parameters of auto-expansion of COW-file.
-    * `step_size`: Expansion step size (in bytes)
-    * `steps`: Steps the DattoBD allowed to do (-1 if unlimited).
+    * `step_size_mib`: Expansion step size (in megabytes).
+    * `reserved_space_mib`: Space that has to be left available for users during auto-expand process (in megabytes).
 * `error`: This field will only be present if the device has failed. It shows the linux standard error code indicating what went wrong. More specific info is printed to dmesg.
 * `state`: An integer representing the current working state of the device. There are 6 possible states; for more info on these refer to [STRUCTURE.md](doc/STRUCTURE.md).
 	* 0 = dormant incremental

--- a/doc/dbdctl.8
+++ b/doc/dbdctl.8
@@ -75,16 +75,16 @@ Cleanly and completely removes the snapshot or incremental, unlinking the associ
 Allows you to reconfigure various parameters of a snapshot while it is online\. Currently only the index cache size (given in MB) can be changed dynamically\.
 .
 .SS "expand-cow-file"
-\fBdbdctl expand-cow-file <minor> <size>\fR
+\fBdbdctl expand-cow-file <size> <minor>\fR
 .
 .P
-Expands cow file in snapshot mode by size (given in bytes)\.
+Expands cow file in snapshot mode by size (given in megabytes)\.
 .
 .SS "reconfigure-auto-expand"
-\fBdbdctl reconfigure-auto-expand [-n <steps limit>] <step size> <minor>\fR
+\fBdbdctl reconfigure-auto-expand [-r <reserved space>] <step size> <minor>\fR
 .
 .P
-Enable auto-expand of cow file in snapshot mode by <step size> (given in bytes), limited with <steps limit> steps (or -1 if unlimited)\.
+Enable auto-expand of cow file in snapshot mode by <step size> (given in megabytes). Auto-expand works in that way that at least <reserved space> (given in megabytes) is left available after each step for regular users of filesystem\.
 .
 .SS "EXAMPLES"
 \fB# dbdctl setup\-snapshot /dev/sda1 /var/backup/datto 4\fR

--- a/doc/dbdctl.8.html
+++ b/doc/dbdctl.8.html
@@ -142,15 +142,15 @@
 
 <h3 id="expand-cow-file">expand-cow-file</h3>
 
-<p><code>dbdctl expand-cow-file &lt;minor&gt; &lt;size&gt;</code></p>
+<p><code>dbdctl expand-cow-file &lt;size&gt; &lt;minor&gt;</code></p>
 
-<p>Expands cow file in snapshot mode by size (given in bytes).</p>
+<p>Expands cow file in snapshot mode by size (given in megabytes).</p>
 
 <h3 id="reconfigure-auto-expand">reconfigure-auto-expand</h3>
 
-<p><code>dbdctl reconfigure-auto-expand [-n &lt;steps limit&gt;] &lt;step size&gt; &lt;minor&gt;</code></p>
+<p><code>dbdctl reconfigure-auto-expand [-r &lt;reserved space&gt;] &lt;step size&gt; &lt;minor&gt;</code></p>
 
-<p>Enable auto-expand of cow file in snapshot mode by &lt;step size&gt; (given in bytes), limited with &lt;steps limit&gt; steps (or -1 if unlimited).</p>
+<p>Enable auto-expand of cow file in snapshot mode by &lt;step size&gt; (given in megabytes). Auto-expand works in that way that at least &lt;reserved space&gt; (given in megabytes) is left available after each step for regular users of filesystem.</p>
 
 <h3 id="EXAMPLES">EXAMPLES</h3>
 

--- a/doc/dbdctl.8.md
+++ b/doc/dbdctl.8.md
@@ -65,15 +65,15 @@ Allows you to reconfigure various parameters of a snapshot while it is online. C
 
 ### expand-cow-file
 
-`dbdctl expand-cow-file <minor> <size>`
+`dbdctl expand-cow-file <size> <minor>`
 
-Expands cow file in snapshot mode by size (given in bytes).
+Expands cow file in snapshot mode by size (given in megabytes).
 
 ### reconfigure-auto-expand
 
 `dbdctl reconfigure-auto-expand [-n <steps limit>] <step size> <minor>`
 
-Enable auto-expand of cow file in snapshot mode by <step size> (given in bytes), limited with <steps limit> steps (or -1 if unlimited).
+Enable auto-expand of cow file in snapshot mode by <step size> (given in megabytes). Auto-expand works in that way that at least <reserved space> (given in megabytes) is left available after each step for regular users of filesystem.
 
 ### EXAMPLES
 

--- a/lib/libdattobd.c
+++ b/lib/libdattobd.c
@@ -155,11 +155,12 @@ int dattobd_get_free_minor(void){
 	return ret;
 }
 
-int dattobd_expand_cow_file(unsigned int minor, unsigned long size){
+int dattobd_expand_cow_file(unsigned int minor, uint64_t size){
 	int fd, ret;
-	struct expand_cow_file_params params;
-	params.minor=minor;
-	params.size=size;
+	struct expand_cow_file_params params = {
+		.size = size,
+		.minor = minor
+	};
 
 	fd = open("/dev/datto-ctl", O_RDONLY);
 	if(fd < 0) return -1;
@@ -170,12 +171,13 @@ int dattobd_expand_cow_file(unsigned int minor, unsigned long size){
 	return ret;
 }
 
-int dattobd_reconfigure_auto_expand(unsigned int minor, uint64_t step_size, long steps){
+int dattobd_reconfigure_auto_expand(unsigned int minor, uint64_t step_size, uint64_t reserved_space){
 	int fd, ret;
-	struct reconfigure_auto_expand_params params;
-	params.minor=minor;
-	params.step_size=step_size;
-	params.steps=steps;
+	struct reconfigure_auto_expand_params params = {
+		.step_size = step_size,
+		.reserved_space = reserved_space,
+		.minor = minor
+	};
 
 	fd = open("/dev/datto-ctl", O_RDONLY);
 	if(fd < 0) return -1;

--- a/lib/libdattobd.h
+++ b/lib/libdattobd.h
@@ -29,9 +29,9 @@ int dattobd_reconfigure(unsigned int minor, unsigned long cache_size);
 
 int dattobd_info(unsigned int minor, struct dattobd_info *info);
 
-int dattobd_expand_cow_file(unsigned int minor, unsigned long size);
+int dattobd_expand_cow_file(unsigned int minor, uint64_t size);
 
-int dattobd_reconfigure_auto_expand(unsigned int minor, uint64_t step_size, long steps);
+int dattobd_reconfigure_auto_expand(unsigned int minor, uint64_t step_size, uint64_t reserved_space);
 
 /**
  * Get the first available minor.

--- a/src/blkdev.h
+++ b/src/blkdev.h
@@ -37,4 +37,6 @@ void dattobd_drop_super(struct super_block *sb);
 void dattobd_blkdev_put(struct block_device *bd);
 
 int dattobd_get_start_sect_by_gendisk_for_bio(struct gendisk* gd, u8 partno, sector_t* result);
+
+int dattobd_get_kstatfs(struct block_device* bd, struct kstatfs* statfs);
 #endif /* BLKDEV_H_ */

--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -8,6 +8,7 @@
 #include "filesystem.h"
 #include "logging.h"
 #include "tracer.h"
+#include "blkdev.h"
 
 #ifdef HAVE_UUID_H
 #include <linux/uuid.h>
@@ -947,14 +948,27 @@ static int __cow_write_data(struct cow_manager *cm, void *buf)
         int abs_path_len;
         uint64_t curr_size = cm->curr_pos * COW_BLOCK_SIZE;
         uint64_t expand_allowance = 0;
+        int kstatfs_ret;
+        struct kstatfs kstatfs;
 
 retry:
         if (curr_size >= cm->file_size) {
                 // try expansion of cow_file
                 if(cm->auto_expand){
-                        expand_allowance = cow_auto_expand_manager_test_and_dec(cm->auto_expand);
+                        kstatfs_ret = 0;
+                        if(cm->dev && cm->dev->sd_base_dev){
+                                kstatfs_ret = dattobd_get_kstatfs(cm->dev->sd_base_dev, &kstatfs);
+                        }
+
+                        if(!kstatfs_ret){
+                                expand_allowance = cow_auto_expand_manager_get_allowance(cm->auto_expand, kstatfs.f_bavail, (uint64_t) kstatfs.f_bsize);
+                        }else{
+                                LOG_WARN("failed to get kstatfs with error code %d, expansion allowance won't consider reserved space", kstatfs_ret);
+                                expand_allowance = cow_auto_expand_manager_get_allowance_no_reserved(cm->auto_expand);
+                        }
+
                         if(expand_allowance){
-                                ret = tracer_expand_cow_file(cm->dev, expand_allowance);
+                                ret = tracer_expand_cow_file_no_check(cm->dev, expand_allowance);
                                 expand_allowance = 0;
                                 if(ret)
                                         goto error;
@@ -1203,16 +1217,16 @@ out:
 }
 
 
-int __cow_expand_datastore(struct cow_manager* cm, uint64_t append_size){
+int __cow_expand_datastore(struct cow_manager* cm, uint64_t append_size_bytes){
         int ret;
         uint64_t actual = 0;
 
-        LOG_DEBUG("trying to expand cow file with %llu bytes", append_size);
+        LOG_DEBUG("trying to expand cow file with %llu bytes", append_size_bytes);
 
-        ret = file_allocate(cm->dfilp, cm->dev, cm->file_size, append_size, &actual);
+        ret = file_allocate(cm->dfilp, cm->dev, cm->file_size, append_size_bytes, &actual);
 
-        if(actual != append_size){
-                LOG_WARN("cow file was not expanded to requested size (req: %llu, act: %llu)", append_size, actual);
+        if(actual != append_size_bytes){
+                LOG_WARN("cow file was not expanded to requested size (req: %llu, act: %llu)", append_size_bytes, actual);
         }
 
         cm->file_size = cm->file_size + actual;
@@ -1237,39 +1251,70 @@ struct cow_auto_expand_manager* cow_auto_expand_manager_init(void){
         return aem;
 }
 
-int cow_auto_expand_manager_reconfigure(struct cow_auto_expand_manager* aem, uint64_t step_size, long steps){
+int cow_auto_expand_manager_reconfigure(struct cow_auto_expand_manager* aem, uint64_t step_size_mib, uint64_t reserved_space_mib){
         mutex_lock(&aem->lock);
-        aem->step_size = step_size;
-        aem->steps = steps;
+        aem->step_size_mib = step_size_mib;
+        aem->reserved_space_mib = reserved_space_mib;
         mutex_unlock(&aem->lock);
         return 0;
 }
 
 /*
-* cow_auto_expand_manager_test_and_dec() - Tests if the auto expand manager has steps remaining and decrements the steps if so.
+* cow_auto_expand_manager_get_allowance() - Tests if the auto expand manager has steps remaining regarding to the available blocks and block size.
 *
-* @aem: The &struct cow_auto_expand_manager to test and decrement.
+* @aem: The &struct cow_auto_expand_manager.
+* @available_blocks: The number of available blocks on the block device. (from kstatfs, f_bavail)
+* @block_size: The size of a block on the block device. (from kstatfs, f_bsize)
 *
 * Return:
 * 0 - no steps remaining
 * !0 - size to expand the cow file by
 */
-uint64_t cow_auto_expand_manager_test_and_dec(struct cow_auto_expand_manager* aem){
+uint64_t cow_auto_expand_manager_get_allowance(struct cow_auto_expand_manager* aem, uint64_t available_blocks, uint64_t block_size_bytes){
+        #define ceil(a, b) (((a)+(b)-1)/(b))
+        #define mib_to_bytes(a) ((a)*1024*1024)
+        
         uint64_t ret;
 
         ret = 0;
         mutex_lock(&aem->lock);
-        if(aem->steps > 0){
-                aem->steps--;
-                ret = aem->step_size;
-        }else if(aem->steps == -1){
-                // infinite steps
-                ret = aem->step_size;
+        if(aem->step_size_mib && ceil(mib_to_bytes(aem->step_size_mib + aem->reserved_space_mib), block_size_bytes) <= available_blocks){
+                ret = mib_to_bytes(aem->step_size_mib);
+        }else{
+                if(aem->step_size_mib){
+                        LOG_WARN("rejected auto-expand: %llu MiB step size, %llu MiB reserved space, %llu blocks available, %llu B block size",
+                                aem->step_size_mib, aem->reserved_space_mib, available_blocks, block_size_bytes);
+                }
         }
         mutex_unlock(&aem->lock);
 
         return ret;
 }
+
+/*
+* cow_auto_expand_manager_get_allowance_no_reserved() - Tests if the auto expand manager has steps remaining without considering reserved space.
+*
+* @aem: The &struct cow_auto_expand_manager.
+*
+* Return:
+* 0 - no steps remaining
+* !0 - size to expand the cow file by
+*/
+uint64_t cow_auto_expand_manager_get_allowance_no_reserved(struct cow_auto_expand_manager* aem){
+        #define mib_to_bytes(a) ((a)*1024*1024)
+        
+        uint64_t ret;
+
+        ret = 0;
+        mutex_lock(&aem->lock);
+        if(aem->step_size_mib){
+                ret = mib_to_bytes(aem->step_size_mib);
+        }
+        mutex_unlock(&aem->lock);
+
+        return ret;
+}
+
 
 void cow_auto_expand_manager_free(struct cow_auto_expand_manager* aem){
         mutex_destroy(&aem->lock);

--- a/src/cow_manager.h
+++ b/src/cow_manager.h
@@ -118,7 +118,7 @@ int cow_auto_expand_manager_reconfigure(struct cow_auto_expand_manager* aem, uin
 
 uint64_t cow_auto_expand_manager_get_allowance(struct cow_auto_expand_manager* aem, uint64_t available_blocks, uint64_t block_size_bytes);
 
-uint64_t cow_auto_expand_manager_get_allowance_no_reserved(struct cow_auto_expand_manager* aem);
+uint64_t cow_auto_expand_manager_get_allowance_free_unknown(struct cow_auto_expand_manager* aem);
 
 void cow_auto_expand_manager_free(struct cow_auto_expand_manager* aem);
 

--- a/src/cow_manager.h
+++ b/src/cow_manager.h
@@ -44,8 +44,8 @@ struct cow_section {
 struct cow_auto_expand_manager {
         struct mutex lock;
 
-        uint64_t step_size;
-        long steps;
+        uint64_t step_size_mib;
+        uint64_t reserved_space_mib;
 };
 
 struct cow_manager {
@@ -110,13 +110,15 @@ int __cow_write_mapping(struct cow_manager *cm, uint64_t pos, uint64_t val);
 
 int cow_get_file_extents(struct snap_device* dev, struct file* filp);
 
-int __cow_expand_datastore(struct cow_manager *cm, uint64_t append_size);
+int __cow_expand_datastore(struct cow_manager *cm, uint64_t append_size_bytes);
 
 struct cow_auto_expand_manager* cow_auto_expand_manager_init(void);
 
-int cow_auto_expand_manager_reconfigure(struct cow_auto_expand_manager* aem, uint64_t step_size, long steps);
+int cow_auto_expand_manager_reconfigure(struct cow_auto_expand_manager* aem, uint64_t step_size_mib, uint64_t reserved_space_mib);
 
-uint64_t cow_auto_expand_manager_test_and_dec(struct cow_auto_expand_manager* aem);
+uint64_t cow_auto_expand_manager_get_allowance(struct cow_auto_expand_manager* aem, uint64_t available_blocks, uint64_t block_size_bytes);
+
+uint64_t cow_auto_expand_manager_get_allowance_no_reserved(struct cow_auto_expand_manager* aem);
 
 void cow_auto_expand_manager_free(struct cow_auto_expand_manager* aem);
 

--- a/src/dattobd.h
+++ b/src/dattobd.h
@@ -47,13 +47,14 @@ struct reconfigure_params {
 };
 
 struct expand_cow_file_params {
+        uint64_t size; // size in mib
+
         unsigned int minor; // minor to extend
-        unsigned long size; // size in bytes
 };
 
 struct reconfigure_auto_expand_params {
-        uint64_t step_size; // step size (in bytes)
-        long steps; // allowed steps (or -1 for unlimited)
+        uint64_t step_size; // step size in mib
+        uint64_t reserved_space; // reserved space in mib
 
         unsigned int minor; // minor to configure
 };

--- a/src/includes.h
+++ b/src/includes.h
@@ -25,5 +25,6 @@
 #include <linux/vmalloc.h>
 #include <linux/fiemap.h>
 #include <linux/types.h>
+#include <linux/statfs.h>
 
 #endif

--- a/src/proc_seq_file.c
+++ b/src/proc_seq_file.c
@@ -210,10 +210,10 @@ static int dattobd_proc_show(struct seq_file *m, void *v)
 
                                 if(dev->sd_cow->auto_expand){
                                         seq_printf(m, "\t\t\t\"auto_expand\": {\n");
-                                        seq_printf(m, "\t\t\t\t\"step_size\": %llu,\n",
-                                                   (unsigned long long)dev->sd_cow->auto_expand->step_size);
-                                        seq_printf(m, "\t\t\t\t\"steps\": %ld\n",
-                                                   dev->sd_cow->auto_expand->steps);
+                                        seq_printf(m, "\t\t\t\t\"step_size_mib\": %llu,\n",
+                                                   (unsigned long long)dev->sd_cow->auto_expand->step_size_mib);
+                                        seq_printf(m, "\t\t\t\t\"reserved_space_mib\": %llu\n",
+                                                   dev->sd_cow->auto_expand->reserved_space_mib);
                                         seq_printf(m, "\t\t\t},\n");
                                 }
                         }

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -2446,15 +2446,15 @@ error:
         tracer_set_fail_state(dev, ret);
 }
 
-int tracer_expand_cow_file(struct snap_device *dev, uint64_t size){
+int tracer_expand_cow_file_no_check(struct snap_device *dev, uint64_t by_size_bytes){
         int ret;
-        LOG_DEBUG("ENTER tracer_expand_cow_file");
+        LOG_DEBUG("ENTER tracer_expand_cow_file_no_check");
         if(tracer_read_fail_state(dev)){
                 LOG_ERROR(-EBUSY, "cannot expand cow file for device in error state");
                 return -EBUSY;
         }
 
-        ret = __cow_expand_datastore(dev->sd_cow, size);
+        ret = __cow_expand_datastore(dev->sd_cow, by_size_bytes);
 
         if(ret){
                 LOG_ERROR(ret, "error expanding cow file");

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -52,7 +52,7 @@ void tracer_reconfigure(struct snap_device *dev, unsigned long cache_size);
 void tracer_dattobd_info(const struct snap_device *dev,
                          struct dattobd_info *info);
 
-int tracer_expand_cow_file(struct snap_device *dev, uint64_t size);
+int tracer_expand_cow_file_no_check(struct snap_device *dev, uint64_t size);
 
 /************************AUTOMATIC TRANSITION FUNCTIONS************************/
 


### PR DESCRIPTION
Now Auto-Expand relies on space left free after the expansion instead of steps limit.

Changes:
- Changed `/proc/datto-info` output to show actual information.
- Aligned `ioctl` calls.
- Renamed things to show more exactly logic they do/contain.
- Implemented `kstatfs` calls to get the free space amount from `struct block_device`
- Auto-Expand manager now relies on amount of free space left after the expansion instead of `steps_limit`