### PR TITLE
[FIX] Mount + File patches

### DIFF
--- a/src/bio_helper.c
+++ b/src/bio_helper.c
@@ -567,6 +567,8 @@ struct inode *page_get_inode(struct page *pg)
                 return NULL;
         if (!pg->mapping)
                 return NULL;
+        if (!virt_addr_valid(pg->mapping))
+		return NULL;
         return pg->mapping->host;
 }
 
@@ -586,7 +588,7 @@ int bio_needs_cow(struct bio *bio, struct inode *inode)
         bio_iter_t iter;
         bio_iter_bvec_t bvec;
 
-#ifdef HAVE_ENUM_REQ_OPF
+#if defined HAVE_ENUM_REQ_OPF || (defined HAVE_ENUM_REQ_OP && defined HAVE_ENUM_REQ_OPF_WRITE_ZEROES)
         //#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)
         if (bio_op(bio) == REQ_OP_WRITE_ZEROES)
                 return 1;

--- a/src/configure-tests/feature-tests/enum_req_op_write_zeroes.c
+++ b/src/configure-tests/feature-tests/enum_req_op_write_zeroes.c
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2025 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+    int a = (int)REQ_OP_WRITE_ZEROES;
+    (void)a;
+}

--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -419,7 +419,7 @@ void cow_free_members(struct cow_manager *cm)
         }
 
         if (cm->dfilp) {
-                file_unlink_and_close_force(cm->dfilp);
+                file_unlink(cm->dfilp);
                 __close_and_destroy_dattobd_mutable_file(cm->dfilp);
                 cm->dfilp = NULL;
         }
@@ -775,7 +775,7 @@ int cow_init(struct snap_device *dev, const char *path, uint64_t elements, unsig
 error:
         LOG_ERROR(ret, "error during cow manager initialization");
         if (cm->dfilp){
-                file_unlink_and_close(cm->dfilp);
+                file_unlink(cm->dfilp);
                 __close_and_destroy_dattobd_mutable_file(cm->dfilp);
                 cm->dfilp = NULL;
         }

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -876,16 +876,14 @@ error:
 }
 
 /**
- * __file_unlink() - delete a name and possibly the file it refers to.
+ * file_unlink() - delete a name and possibly the file it refers to.
  * @dfilp: A dataobd mutable file object.
- * @close: Close the @filp on success.
- * @force: Always close the @filp regardless of a successful unlink.
  *
  * Return:
  * * 0 - success
  * * !0 - errno indicating the error.
  */
-int __file_unlink(struct dattobd_mutable_file *dfilp, int close, int force)
+int file_unlink(struct dattobd_mutable_file *dfilp)
 {
         int ret = 0;
         struct inode *dir_inode = dfilp->dentry->d_parent->d_inode;
@@ -898,8 +896,6 @@ int __file_unlink(struct dattobd_mutable_file *dfilp, int close, int force)
         // }
 
         if (d_unlinked(file_dentry)) {
-                if (close)
-                        file_close(dfilp);
                 return 0;
         }
 
@@ -932,9 +928,7 @@ int __file_unlink(struct dattobd_mutable_file *dfilp, int close, int force)
 
 error:
         mnt_drop_write(mnt);
-
-        if (close && (!ret || force))
-                file_close(dfilp);
+        dattobd_mutable_file_lock(dfilp);
 
 mnt_error:
         iput(dir_inode);

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -19,10 +19,6 @@
 #define _get_macro(_1,_2,_3,_4,_5,_6,NAME,...) NAME
 #define file_write(...) _get_macro(__VA_ARGS__, file_write6, file_write5)(__VA_ARGS__)
 
-#define file_unlink(filp) __file_unlink(filp, 0, 0)
-#define file_unlink_and_close(filp) __file_unlink(filp, 1, 0)
-#define file_unlink_and_close_force(filp) __file_unlink(filp, 1, 1)
-
 // #define file_lock(filp) file_switch_lock(filp, true, false)
 // #define file_unlock(filp) file_switch_lock(filp, false, false)
 // #define file_unlock_mark_dirty(filp) file_switch_lock(filp, false, true)
@@ -100,7 +96,7 @@ int file_truncate(struct dattobd_mutable_file *dfilp, loff_t len);
 
 int file_allocate(struct dattobd_mutable_file *dfilp, struct snap_device* dev, uint64_t offset, uint64_t length, uint64_t *done);
 
-int __file_unlink(struct dattobd_mutable_file* dfilp, int close, int force);
+int file_unlink(struct dattobd_mutable_file* dfilp);
 
 void file_close(struct dattobd_mutable_file *filp);
 


### PR DESCRIPTION
- Patch to handle correctly LVM Groups based on multiple physical volumes
- Patch to handle correctly XFS Filesystems on latest kernels (RHEL9, Ubuntu 24, Debian 12)
- Patch to handle correctly file unlinking, which caused problems for Debian 12

Blocked by #8 